### PR TITLE
Remove line numbers

### DIFF
--- a/manuscript/animating-react-redux.txt
+++ b/manuscript/animating-react-redux.txt
@@ -49,7 +49,7 @@ None of them contain state, but `App` has to be a proper component so that we ca
 
 The `Particle` component is a circle. It looks like this:
 
-{caption: "Particle component", line-numbers: false}
+{caption: "Particle component", line-numbers: off}
 ```javascript
 // src/components/Particles/Particle.jsx
 import React from 'react';
@@ -68,7 +68,7 @@ It takes `x` and `y` coordinates and returns an SVG circle.
 
 The `Particles` component isn't much smarter – it returns a list of circles wrapped in a grouping element, like this:
 
-{caption: "Particles list", line-numbers: false}
+{caption: "Particles list", line-numbers: off}
 ```javascript
 // src/components/Particles/index.jsx
 import React from 'react';
@@ -95,7 +95,7 @@ We can take an array of `{id, x, y}` objects and render SVG circles. Now comes o
 
 The rendering part looks like this:
 
-{caption: "App component", line-numbers: false}
+{caption: "App component", line-numbers: off}
 ```javascript
 // src/components/index.jsx
 
@@ -139,7 +139,7 @@ Oh, and we call `startTicker()` when a user clicks on our scene. No reason to ha
 
 To let users generate particles, we have to wire up some functions in `componentDidMount`. It looks like this:
 
-{caption: "Event listeners", line-numbers: false}
+{caption: "Event listeners", line-numbers: off}
 ```javascript
 // src/components/index.jsx
 
@@ -205,7 +205,7 @@ Redux actions are a fancy way of saying *"Yo, a thing happened!"*. They're funct
 
 Our particle generator uses 6 actions. The most complicated one looks like this:
 
-{caption: "Actions", line-numbers: false}
+{caption: "Actions", line-numbers: off}
 ```javascript
 // src/actions/index.js
 export const CREATE_PARTICLES = 'CREATE_PARTICLES';
@@ -244,7 +244,7 @@ I'm not sure this separation is necessary in small projects. Maintaining it can 
 
 The gist of our `AppContainer` looks like this:
 
-{caption: "Main container component", line-numbers: false}
+{caption: "Main container component", line-numbers: off}
 ```javascript
 // src/containers/AppContainer.jsx
 import { connect } from 'react-redux';
@@ -306,7 +306,7 @@ That's why you should reserve context for passing the Redux store. All component
 
 Congratz, you know the basics! Now we need to define those callbacks so `App` can trigger actions. Most are boilerplate-y action wrappers. Like this:
 
-{caption: "Container-store communication", line-numbers: false}
+{caption: "Container-store communication", line-numbers: off}
 ```javascript
 // src/containers/AppContainer.jsx
 class AppContainer extends Component {
@@ -335,7 +335,7 @@ Redux uses our action, goes to all our reducers, and asks *"Anything you wanna d
 
 We have to look at the `startTicker` callback before we can talk about reducers. It's where our particle generator really begins.
 
-{caption: "startTicker", line-numbers: false}
+{caption: "startTicker", line-numbers: off}
 ```javascript
 // src/containers/AppContainer.jsx
 class AppContainer extends Component {
@@ -389,7 +389,7 @@ All of our logic goes in the reducer. [Dan Abramov says](http://redux.js.org/doc
 
 A "sum numbers" example would look like this:
 
-{caption: "Reducer concept", line-numbers: false}
+{caption: "Reducer concept", line-numbers: off}
 ```javascript
 let sum = [1,2,3,4].reduce((sum, n) => sum+n, 0);
 ```
@@ -402,7 +402,7 @@ To keep the example code simple, we'll put everything into the same reducer and 
 
 Let's start with the basics:
 
-{caption: "Redux reducer basic state", line-numbers: false}
+{caption: "Redux reducer basic state", line-numbers: off}
 ```javascript
 // src/reducers/index.js
 const Gravity = 0.5,
@@ -446,7 +446,7 @@ Our reducer doesn't change anything yet. You should always return at least the s
 
 For most actions, our reducer updates a single value. Like this:
 
-{caption: "Reducer big switch", line-numbers: false}
+{caption: "Reducer big switch", line-numbers: off}
 ```javascript
 // src/reducers/index.js
 function particlesApp(state = initialState, action) {
@@ -482,7 +482,7 @@ You can also use a library like [immutable.js](https://facebook.github.io/immuta
 
 Those state updates were boilerplate. The important ones are each tick of the game loop and creating new particles. They look like this:
 
-{caption: "The core particles logic", line-numbers: false}
+{caption: "The core particles logic", line-numbers: off}
 ```javascript
 // src/reducers/index.js
 function particlesApp(state = initialState, action) {

--- a/manuscript/animation.md
+++ b/manuscript/animation.md
@@ -41,7 +41,7 @@ I suggest you follow along on CodePen. Here's one I prepared for you earlier: [c
 
 We start with a skeleton: An empty `Ball` component, and an `App` component stubbed out to run the game loop.
 
-{caption: "Bouncy ball skeleton", line-numbers: false}
+{caption: "Bouncy ball skeleton", line-numbers: off}
 ```javascript
 const Ball = ({ x, y }) => (
 
@@ -85,7 +85,7 @@ The default state sets our ball's `y` coordinate to `5` and its vertical speed �
 
 We can approximate the `Ball` component with a circle. No need to get fancy; we're focusing on the animations part.
 
-{caption: "A Ball is a circle", line-numbers: false}
+{caption: "A Ball is a circle", line-numbers: off}
 ```javascript
 const Ball = ({ x, y }) => (
   <circle cx={x} cy={y} r={5} />
@@ -100,7 +100,7 @@ It's these coordinates that we're going to play with to make the ball drop and b
 
 We need an SVG of appropriate height and a ball inside. All that goes in `App.render`.
 
-{caption: "Render ball", line-numbers: false}
+{caption: "Render ball", line-numbers: off}
 ```javascript
 class App extends Component {
 	// ...
@@ -124,7 +124,7 @@ A black ball should show up on your screen. Like this:
 
 To make the ball bounce, we need to start an infinite loop when our component first renders, change the ball's `y` coordinate on every iteration, and stop the loop when React unmounts our component. Wouldn't want to keep hogging resources, would we?
 
-{caption: "Change ball position at 60fps", line-numbers: false}
+{caption: "Change ball position at 60fps", line-numbers: off}
 ```javascript
 componentDidMount() {
     this.timer = d3.timer(() => this.gameLoop());
@@ -181,7 +181,7 @@ Modern browsers slow down JavaScript in tabs that aren't focused, on computers r
 
 We have to calculate how much time each frame took and adjust our physics.
 
-{caption: "Adjust for frame drops", line-numbers: false}
+{caption: "Adjust for frame drops", line-numbers: off}
 ```javascript
 gameLoop() {
     let { y, vy, lastFrame } = this.state;
@@ -242,7 +242,7 @@ You can play with the code on CodePen [here](http://codepen.io/swizec/pen/QdVoOg
 
 The App component only needs  a `render` method that returns an SVG. Yes, that means it could've been a functional stateless component.
 
-{caption: "App render method", line-numbers: false}
+{caption: "App render method", line-numbers: off}
 ```javascript
 class App extends Component {
   render() {
@@ -285,7 +285,7 @@ Notice that unlike thus far, we didn't mess about with `updateD3` and lifecycle 
 
 The Dot component has more moving parts. It needs a `constructor`, a transition callback – `flash`, a `color` getter, and a `render` method.
 
-{caption: "Dot component skeleton", line-numbers: false}
+{caption: "Dot component skeleton", line-numbers: off}
 ```javascript
 class Dot extends Component {
   constructor(props) {
@@ -330,7 +330,7 @@ For the `render` method, we return an SVG `<circle>` element positioned at `(x, 
 
 When you mouse over one of the dots, its `flash()` method gets called as an event callback. This is where we transition to pop the circle bigger then back to normal size.
 
-{caption: "Main Dot transition effect", line-numbers: false}
+{caption: "Main Dot transition effect", line-numbers: off}
 ```javascript
   flash() {
     let node = d3.select(this.refs.circle);
@@ -374,7 +374,7 @@ Colors follow a radial pattern even though `d3.interpolateWarm` takes a single a
 
 Calibrate a linear scale to translate between `[0, maxR^2]` and `[0, 1]`, then feed it `x^2 + y^2`, and you get the `interpolateWarm` parameter. Magic :smile:
 
-{caption: "Radial coloring effect", line-numbers: false}
+{caption: "Radial coloring effect", line-numbers: off}
 ```javascript
   get color() {
     const { x, y, maxPos } = this.state;
@@ -448,7 +448,7 @@ The `Alphabet` component holds a list of letters in local state and renders a co
 
 We start with a skeleton like this:
 
-{caption: "Alphabet skeleton", line-numbers: false}
+{caption: "Alphabet skeleton", line-numbers: off}
 ```javascript
 // src/components/Alphabet.js
 import React, { Component } from 'react';
@@ -477,7 +477,7 @@ We import our dependencies and define the `Alphabet` component. It holds a list 
 
 To showcase enter-update-exit transitions, we want to create a new alphabet every couple of seconds. That's easiest to do in `componentWillMount`:
 
-{caption: "Alphabet game loop", line-numbers: false}
+{caption: "Alphabet game loop", line-numbers: off}
 ```javascript
 // src/components/Alphabet/index.js
     componentWillMount() {
@@ -497,7 +497,7 @@ Starting the interval in `componentWillMount` ensures it only runs when our Alph
 
 Our declarative transitions magic starts in the `render` method.
 
-{caption: "Letter rendering", line-numbers: false}
+{caption: "Letter rendering", line-numbers: off}
 ```javascript
 // src/components/Alphabet/index.js
     render() {
@@ -547,7 +547,7 @@ Now we're ready for the component that can transition itself into and out of a v
 
 The skeleton of our `Letter` component looks like this:
 
-{caption: "Letter component skeleton", line-numbers: false}
+{caption: "Letter component skeleton", line-numbers: off}
 ```javascript
 // src/components/Alphabet/Letter.js
 
@@ -601,7 +601,7 @@ All our magic values – default/final `y` coordinate, transition properties, et
 
 We start with the enter transition in `componentWillEnter`.
 
-{caption: "Enter transition", line-numbers: false}
+{caption: "Enter transition", line-numbers: off}
 ```javascript
 // src/components/Alphabet/Letter.js
     componentWillEnter(callback) {
@@ -639,7 +639,7 @@ We can sync React's imagination with reality in a "transition is over" callback 
 
 The exit transition goes in `componentWillLeave` and follows the same principle, except in reverse. It looks like this:
 
-{caption: "Leave transition", line-numbers: false}
+{caption: "Leave transition", line-numbers: off}
 ```javascript
 // src/components/Alphabet/
     componentWillLeave(callback) {
@@ -668,7 +668,7 @@ On second though, we might not need to update state in this case. The component 
 
 The update transition goes into `componentWillReceiveProps` like this:
 
-{caption: "Update transition", line-numbers: false}
+{caption: "Update transition", line-numbers: off}
 ```javascript
 // src/components/Alphabet/Letter.js
     componentWillReceiveProps(nextProps) {
@@ -698,7 +698,7 @@ After all that transition magic, you might be thinking *"Holy shit, how do I ren
 
 But we did the hard work. Rendering is straightforward:
 
-{caption: "Letter render method", line-numbers: false}
+{caption: "Letter render method", line-numbers: off}
 ```javascript
 // src/components/Alphabet/Letter.js
     render() {

--- a/manuscript/introduction.txt
+++ b/manuscript/introduction.txt
@@ -114,7 +114,7 @@ class App ...
 
 Commands that you should run in the terminal start with an `$` symbol, like this:
 
-{line-numbers: false}
+{line-numbers: off}
 ```
 $ npm start
 ```

--- a/manuscript/simpler-environment.md
+++ b/manuscript/simpler-environment.md
@@ -46,7 +46,7 @@ Superb! You have `create-react-app`. Time to create an app and get started with 
 
 Run this in a terminal:
 
-{caption: "Create your project", line-numbers: false}
+{caption: "Create your project", line-numbers: off}
 ```
 $ create-react-app react-d3js-example
 ```
@@ -101,14 +101,14 @@ There are a couple of libraries we're going to use often in this book: D3, Topoj
 
 You can install them like this:
 
-{caption: "Install dependencies", line-numbers: false}
+{caption: "Install dependencies", line-numbers: off}
 ```
 $ npm install --save d3 topojson lodash
 ```
 
 Additionally, we're using Bootstrap for default styling and String for string manipulation. You should install them as well.
 
-{caption: "Styling and string manipulation", line-numbers: false}
+{caption: "Styling and string manipulation", line-numbers: off}
 ```
 $ npm install --save bootstrap string
 ```

--- a/manuscript/speed-optimizations.txt
+++ b/manuscript/speed-optimizations.txt
@@ -108,7 +108,7 @@ If anything looks weird or doesn't work, I've prepared a helpful [GitHub branch]
 
 You should go into your particle generator directory, install Konva and react-konva, and then make the changes below. Trying things out is better than just reading my code ;)
 
-{caption: "Install Konva", line-numbers: false}
+{caption: "Install Konva", line-numbers: off}
 ```
 $ npm install --save konva react-konva
 ```
@@ -123,7 +123,7 @@ Our changes start in `src/components/index.jsx`. We have to throw away the `<svg
 
 You can think of a Konva stage as a Canvas element with a bunch of helper methods attached. Some of them Konva uses internally; others are exposed as an API. Functions like exporting to an image file, detecting intersections, etc.
 
-{caption: "Import Konva and set the stage", line-numbers: false}
+{caption: "Import Konva and set the stage", line-numbers: off}
 ```javascript
 // src/components/index.jsx
 
@@ -170,7 +170,7 @@ Because the new approach renders a flat image, and because we don't care about i
 
 The new `Particles` component looks like this:
 
-{caption: "Sprite-based Particles component", line-numbers: false}
+{caption: "Sprite-based Particles component", line-numbers: off}
 ```javascript
 // src/components/Particles.jsx
 
@@ -220,7 +220,7 @@ export default Particles;
 
 #### componentDidMount
 
-{caption: "componentDidMount code", line-numbers: false}
+{caption: "componentDidMount code", line-numbers: off}
 ```javascript
 // src/components/Particles.jsx
 
@@ -254,7 +254,7 @@ You might be thinking that it's unsafe to copy references to rendered elements i
 
 #### drawParticle
 
-{caption: "drawParticle code", line-numbers: false}
+{caption: "drawParticle code", line-numbers: off}
 ```javascript
 // src/components/Particles.jsx
 
@@ -274,7 +274,7 @@ We use the whole sprite, corner `(0, 0)` to corner `(128, 128)`. That's how big 
 
 #### componentDidUpdate
 
-{caption: "componentDidUpdate code", line-numbers: false}
+{caption: "componentDidUpdate code", line-numbers: off}
 ```javascript
 // src/components/Particles.jsx
 
@@ -311,7 +311,7 @@ You can open your browser console to see how long it takes to draw a frame. That
 
 #### render
 
-{caption: "render code", line-numbers: false}
+{caption: "render code", line-numbers: off}
 ```javascript
 // src/components/Particles.jsx
 
@@ -365,14 +365,14 @@ About two years ago, decorators got very close to becoming an official spec, the
 
 You can think of decorators as function wrappers. Instead of something like this:
 
-{caption: "Decoratorless function wrapping", line-numbers: false}
+{caption: "Decoratorless function wrapping", line-numbers: off}
 ```javascript
 inject('store', ({ store }) => <div>A thing with {store.value}</div>);
 ```
 
 You can write something like this:
 
-{caption: "Function wrapping with decorators", line-numbers: false}
+{caption: "Function wrapping with decorators", line-numbers: off}
 ```javascript
 @inject('store')
 ({ store }) => <div>A thing with {store.value}</div>
@@ -388,7 +388,7 @@ Because decorators aren't in the JavaScript spec, we have to tweak how we start 
 
 You should start a new project like this:
 
-{caption: "Create the billiards game project", line-numbers: false}
+{caption: "Create the billiards game project", line-numbers: off}
 ```
 $ create-react-app billiards-game --scripts-version custom-react-scripts
 ```
@@ -399,7 +399,7 @@ The addition of `--scripts-version custom-react-scripts` employs @kitze's [custo
 
 We enable them in the `.env` file. Add this line:
 
-{caption: "Add to .env settings", line-numbers: false}
+{caption: "Add to .env settings", line-numbers: off}
 ```
 // billiards-game/.env
 // ...
@@ -410,7 +410,7 @@ No installation necessary. I think `custom-react-scripts` uses the `transform-de
 
 Before we begin, you should install the other dependencies as well:
 
-{caption: "Install libraries", line-numbers: false}
+{caption: "Install libraries", line-numbers: off}
 ```
 $ npm install --save konva react-konva mobx mobx-react d3-timer d3-scale d3-quadtree
 ```
@@ -462,7 +462,7 @@ Let's start with `App` and work our way down.
 
 Our `App` component doesn't do much. It imports our MobX stores, triggers sprite loading, and starts the game loop.
 
-{caption: "The App component", line-numbers: false}
+{caption: "The App component", line-numbers: off}
 ```javascript
 // src/components/App.js
 
@@ -513,7 +513,7 @@ Even though `MarbleList` is an important component that basically renders the wh
 
 Like this:
 
-{caption: "MarbleList component", line-numbers: false}
+{caption: "MarbleList component", line-numbers: off}
 ```javascript
 // src/components/MarbleList.js
 
@@ -568,7 +568,7 @@ Each `Marble` component renders a single marble and handles dragging and droppin
 
 The component looks like this:
 
-{caption: "Marble component", line-numbers: false}
+{caption: "Marble component", line-numbers: off}
 ```javascript
 // src/components/Marble.js
 
@@ -632,7 +632,7 @@ That said, I would recommend using explicit `@actions` in larger projects.
 
 Here's what the dragging callbacks look like.
 
-{caption: "Dragging callbacks", line-numbers: false}
+{caption: "Dragging callbacks", line-numbers: off}
 ```javascript
 // src/components/Marble.js
 
@@ -705,7 +705,7 @@ To use this, we need two things:
 
 The first is a `MarbleDefinitions` dictionary. We used it in `Marble` component's render method.
 
-{caption: "MarbleDefinitions dictionary", line-numbers: false}
+{caption: "MarbleDefinitions dictionary", line-numbers: off}
 ```javascript
 // src/logic/Sprite.js
 
@@ -732,7 +732,7 @@ All values were painstakingly assembled by hand. You're welcome.
 
 The MobX store that loads our sprite into memory and helps us use it looks like this:
 
-{caption: "Sprite store", line-numbers: false}
+{caption: "Sprite store", line-numbers: off}
 ```javascript
 // src/logic/Sprite.js
 
@@ -792,7 +792,7 @@ The general approach goes like this:
 
 The [whole Physics store](https://github.com/Swizec/declarative-canvas-react-konva/blob/master/src/logic/Physics.js) is some 120 lines of code, so I won't share it all at once. Here's what its skeleton looks like:
 
-{caption: "Physics skeleton", line-numbers: false}
+{caption: "Physics skeleton", line-numbers: off}
 ```javascript
 // src/logic/Physics.js
 
@@ -827,7 +827,7 @@ Let's walk through.
 
 #### initialPositions
 
-{caption: "initialPositions function", line-numbers: false}
+{caption: "initialPositions function", line-numbers: off}
 ```javascript
 // src/logic/Physics.js
 class Physics {
@@ -887,7 +887,7 @@ In the end, we add an `id` to each marble. We're using index as the id, that's t
 
 #### shoot and startGameLoop
 
-{caption: "shoot and startGameLoop functions", line-numbers: false}
+{caption: "shoot and startGameLoop functions", line-numbers: off}
 ```javascript
 // src/logic/Physics.js
 class Physics {
@@ -922,7 +922,7 @@ Here comes the fun part. The one with our game loop.
 
 I've also made a video of all this. [Watch it on YouTube](https://www.youtube.com/watch?v=H84fmXjTElM). It involves hand-drawn sketches that explain the math, and I think that's neat.
 
-{caption: "Full simulationStep function", line-numbers: false}
+{caption: "Full simulationStep function", line-numbers: off}
 ```javascript
 
 @action simulationStep() {
@@ -984,7 +984,7 @@ That's a lot of code 😅. Let's break it down.
 
 You can think of `simulationStep` as a function and a loop. At the bottom, there is a `.forEach` that applies a `moveMarble` function to each marble.
 
-{caption: "Loop through marbles", line-numbers: false}
+{caption: "Loop through marbles", line-numbers: off}
 ```javascript
     this.marbles.forEach((marble, i) => {
         const { x, y, vx, vy } = moveMarble(marble);
@@ -1010,7 +1010,7 @@ I wonder why I did it like this :thinking_face: Maybe a leftover from before Mob
 
 **Handling collisions with walls happens** in two lines of code. One per coordinate.
 
-{caption: "Detecting wall collisions", line-numbers: false}
+{caption: "Detecting wall collisions", line-numbers: off}
 ```javascript
 let _vx = ((x+vx < MarbleR) ? -vx : (x+vx > width-MarbleR) ? -vx : vx)*.99,
     _vy = ((y+vy < MarbleR) ? -vy : (y+vy > height-MarbleR) ? -vy : vy)*.99;
@@ -1026,7 +1026,7 @@ A quadtree is a good way to subdivide space into areas. It lets us answer the qu
 Checking every marble with every other marble produces 81 comparisons. Versus 2 comparisons using a quadtree.
 {/aside}
 
-{caption: "Finding collision candidates", line-numbers: false}
+{caption: "Finding collision candidates", line-numbers: off}
 ```javascript
 // nearest marble is a collision candidate
 const subdividedSpace = quadtree().extent([[-1, -1],
@@ -1048,7 +1048,7 @@ Once we have a quadtree built out, we use `.find` to look for the nearest marble
 
 The code looks like this:
 
-{caption: "Handling marble collisions", line-numbers: false}
+{caption: "Handling marble collisions", line-numbers: off}
 ```javascript
 if (candidate) {
 
@@ -1131,7 +1131,7 @@ We're using a `<Pythagoras>` component for each square and its two children, a D
 
 The `<Pythagoras>` component looks like this:
 
-{caption: "Recursive <Pythagoras> component", line-numbers: false}
+{caption: "Recursive <Pythagoras> component", line-numbers: off}
 ```
 const Pythagoras = ({ w, x, y, heightFactor, lean, left, right, lvl, maxlvl }) => {
     if (lvl >= maxlvl || w < 1) {
@@ -1190,7 +1190,7 @@ Most of this code deals with passing arguments onwards to children, which isn't 
 
 I don't _really_ understand this math, but I sort of know where it's coming from. It's the [sine law](https://en.wikipedia.org/wiki/Law_of_sines) applied correctly. The part I failed at miserably [when I tried](https://swizec.com/blog/fractals-react/swizec/7233).
 
-{caption: "Trigonometry that moves our fractal", line-numbers: false}
+{caption: "Trigonometry that moves our fractal", line-numbers: off}
 ```
 const memoizedCalc = function () {
     const memo = {};
@@ -1237,7 +1237,7 @@ This, however, would be tricky to implement. A lot more computation, I think.
 
 Inside [`App.js`](https://github.com/Swizec/react-fractals/blob/master/src/App.js), we add a mouse event listener. We use D3's because it gives us SVG-relative position calculation out of the box. With React's, we'd have to do the hard work ourselves.
 
-{caption: "Reacting to mouse movement", line-numbers: false}
+{caption: "Reacting to mouse movement", line-numbers: off}
 ```
 // App.js
 state = {
@@ -1294,7 +1294,7 @@ The `lean` parameter tells us which way the tree is leaning and by how much, the
 
 That happens in `onMouseMove`:
 
-{caption: "Moving the fractal as user moves mouse", line-numbers: false}
+{caption: "Moving the fractal as user moves mouse", line-numbers: off}
 ```
 onMouseMove(event) {
 	const [x, y] = d3mouse(this.refs.svg),
@@ -1348,7 +1348,7 @@ In `package.json`, he added `preact`, `preact-compat`, and preact -compat clones
 
 He changed the functional stateless `Pythagoras` component into a stateful component to enable async rendering.
 
-{caption: "Change <Pythagoras> to a class", line-numbers: false}
+{caption: "Change <Pythagoras> to a class", line-numbers: off}
 ```
 // src/Pythagoras.js
 export default class {
@@ -1360,7 +1360,7 @@ export default class {
 
 And enabled debounced asynchronous rendering:
 
-{caption: "Debounce rendering", line-numbers: false}
+{caption: "Debounce rendering", line-numbers: off}
 ```
 // src/index.js
 import { options } from 'preact';
@@ -1389,7 +1389,7 @@ From there, the main changes are to the imports – React becomes Inferno – 
 
 He also had to change a string-based ref into a callback ref. Inferno doesn't do string-based refs for performance reasons, and we need refs so we can use D3 to detect mouse position on SVG.
 
-{caption: "Change ref to callback", line-numbers: false}
+{caption: "Change ref to callback", line-numbers: off}
 ```
 // src/App.js
 

--- a/manuscript/the-meat-start.txt
+++ b/manuscript/the-meat-start.txt
@@ -75,7 +75,7 @@ A lot of what you end up doing in real life is finding a D3 example that looks l
 
 But D3 is hard to read. Take this barchart code, for example 👇
 
-{caption: "Barchart in pure D3", line-numbers: false}
+{caption: "Barchart in pure D3", line-numbers: off}
 ```javascript
 d3.tsv("data.tsv", function(d) {
   d.frequency = +d.frequency;
@@ -145,7 +145,7 @@ You can [try it online](https://cdn.rawgit.com/mbostock/3885304/raw/a91f37f5f4b4
 
 Mike Bostock, the creator of D3, built this chart in 43 lines of code. Here they are 👇
 
-{caption: "Example D3 barchart", line-numbers: false}
+{caption: "Example D3 barchart", line-numbers: off}
 ```javascript
 var svg = d3.select("svg"),
     margin = {top: 20, right: 20, bottom: 30, left: 40},
@@ -195,7 +195,7 @@ d3.tsv("data.tsv", function(d) {
 
 There are two parts to this code: Data manipulation and DOM manipulation.
 
-{caption: "Data manipulation code", line-numbers: false}
+{caption: "Data manipulation code", line-numbers: off}
 ```javascript
 var // ..,
     margin = {top: 20, right: 20, bottom: 30, left: 40},
@@ -228,7 +228,7 @@ Bostock here first prepares his data:
 
 In the DOM manipulation part, he puts shapes and objects into an SVG. This is the part that shows up in your browser.
 
-{caption: "DOM manipulation code", line-numbers: false}
+{caption: "DOM manipulation code", line-numbers: off}
 ```javascript
 var svg = d3.select("svg"),
     // ..
@@ -358,7 +358,7 @@ There's a lot. We're not going to cover it all but you can find those advanced f
 
 Our visualizations are going to use SVG – an XML-based image format that lets us describe images in terms of mathematical shapes. For example, the source code of an 800x600 SVG image with a rectangle looks like this:
 
-{caption: "SVG rectangle", line-numbers: false}
+{caption: "SVG rectangle", line-numbers: off}
 ```html
 <svg width="800" height="600">
     <rect width="100" height="200" x="50" y="20" />
@@ -377,7 +377,7 @@ Another nice feature of SVG is that it's just a dialect of XML - nested elements
 
 That makes React's rendering engine particularly suited for SVG. Our 100x200 rectangle from before looks like this as a React component:
 
-{caption: "A simple rectangle in React", line-numbers: false, format: javascript}
+{caption: "A simple rectangle in React", line-numbers: off, format: javascript}
 ```
 const Rectangle = () => (
     <rect width="100" height="200" x="50" y="20" />
@@ -386,7 +386,7 @@ const Rectangle = () => (
 
 To use this rectangle component in a picture, you'd use a component like this:
 
-{caption: "Rect component in a picture", line-numbers: false, format: javascript}
+{caption: "Rect component in a picture", line-numbers: off, format: javascript}
 ```
 const Picture = () => (
     <svg width="800" height="600">
@@ -399,7 +399,7 @@ Sure looks like tons of work for a static rectangle. But look closely! Even if y
 
 Compare that to a pure D3 approach:
 
-{caption: "A static rectangle in d3.js", line-numbers: false, format: javascript}
+{caption: "A static rectangle in d3.js", line-numbers: off, format: javascript}
 ```
 d3.select("svg")
   .attr("width", 800)
@@ -417,7 +417,7 @@ You have to take your time and read the code carefully: first, we `select` the `
 
 Those 8 lines of code create HTML that looks like this:
 
-{caption: "HTML of a rectangle", line-numbers: false, format: javascript}
+{caption: "HTML of a rectangle", line-numbers: off, format: javascript}
 ```
 <svg width="800" height="600">
     <rect width="100" height="200" x="50" y="20" />
@@ -472,7 +472,7 @@ Victory offers low level components for basic charting and reimplements a lot of
 
 Here's what it takes to implement a Barchart using Victory.js. [You can try it on CodeSandbox](https://codesandbox.io/s/3v3q013x36)
 
-{caption: "Bar chart in Victory.js", line-numbers: false}
+{caption: "Bar chart in Victory.js", line-numbers: off}
 ```javascript
 const data = [
   { quarter: 1, earnings: 13000 },
@@ -505,7 +505,7 @@ Recharts is like a more colorful Victory. A pile of charting components, some cu
 
 Here's what it takes to implement a Barchart using Recharts. [You can try it on CodeSandbox](https://codesandbox.io/s/mmkrjl7qxp)
 
-{code-samples: "Bar chart in Recharts", line-numbers: false}
+{code-samples: "Bar chart in Recharts", line-numbers: off}
 ```javascript
 const data = [
   { quarter: 1, earnings: 13000 },
@@ -541,7 +541,7 @@ Nivo is another attempt to give you a set of basic charting components. Comes wi
 
 Here's what it takes to implement a Barchart using Nivo. [You can try it on CodeSandbox](https://codesandbox.io/s/n1wwkvq24)
 
-{caption: "Bar chart in Nivo", line-numbers: false}
+{caption: "Bar chart in Nivo", line-numbers: off}
 ```javascript
 const data = [
   { quarter: 1, earnings: 13000 },
@@ -576,7 +576,7 @@ That's why I recommend teams use VX when they need to get started quickly.
 
 Here's what it takes to implement a Barchart using Nivo. [You can try it on CodeSandbox](https://codesandbox.io/s/k5853pryrv)
 
-{caption: "Bar chart built in VX", line-numbers: false}
+{caption: "Bar chart built in VX", line-numbers: off}
 ```javascript
 const data = [
   { quarter: 1, earnings: 13000 },
@@ -673,7 +673,7 @@ They don't *look* difficult, but there are many tiny details you have to get _ju
 
 D3's axis generator takes a scale and some configuration to render an axis for us. The code looks like this:
 
-{caption: "Vanilla D3 axis",line-numbers: false, format: javascript}
+{caption: "Vanilla D3 axis",line-numbers: off, format: javascript}
 ```
 const scale = d3.scaleLinear()
 		.domain([0, 10])
@@ -706,7 +706,7 @@ Play around with it on [Codesandbox](https://codepen.io/swizec/pen/YGoYBM). Chan
 
 Now let's say we want to use that same axis code but as a React component. The simplest way is to use a blackbox component approach like this:
 
-{caption: "React blackbox axis", line-numbers: false, format: javascript}
+{caption: "React blackbox axis", line-numbers: off, format: javascript}
 ```
 class Axis extends Component {
 	gRef = React.createRef();
@@ -772,7 +772,7 @@ Think of our HOC as a function that takes some params and creates a class – a 
 
 A HOC for D3 blackbox integration, called `D3blackbox`, looks like like this:
 
-{caption: "React blackbox HOC", line-numbers: false, format: javascript}
+{caption: "React blackbox HOC", line-numbers: off, format: javascript}
 ```
 function D3blackbox(D3render) {
 	return class Blackbox extends React.Component {
@@ -801,7 +801,7 @@ Consult the [ES6 cheatsheet](https://es6cheatsheet.com/) for details on the synt
 
 Using our new `D3blackbox` HOC to make an axis looks like this:
 
-{caption: "React blackbox HOC", line-numbers: false, format: javascript}
+{caption: "React blackbox HOC", line-numbers: off, format: javascript}
 ```
 const Axis = D3blackbox(function () {
     const scale = d3.scaleLinear()
@@ -837,7 +837,7 @@ With your HOC ready, create a new file in CodeSandbox. Call it `Barchart.js`.
 
 Add your imports:
 
-{caption: "Import dependencies", line-numbers: false}
+{caption: "Import dependencies", line-numbers: off}
 ```javascript
 import React from 'react';
 import D3blackbox from './D3blackbox';
@@ -848,7 +848,7 @@ This gives you React, our HOC, and D3.
 
 Now right-click view code on that barchart and copy the code. Wrap it in a `D3blackbox` call. Like this:
 
-{caption: "Wrap D3 code in D3blackbox", line-numbers: false}
+{caption: "Wrap D3 code in D3blackbox", line-numbers: off}
 ```javascript
 const Barchart = D3blackbox(function () {
 	var svg = d3.select("svg"),
@@ -902,7 +902,7 @@ export default Barchart;
 
 That should throw some errors. We have to change the `d3.select` and get `width` and `height` from props.
 
-{caption: "Change where D3 renders", line-numbers: false}
+{caption: "Change where D3 renders", line-numbers: off}
 ```javascript
 const Barchart = D3blackbox(function () {
   // markua-start-delete
@@ -929,7 +929,7 @@ We also replaced reading width and height from the SVG element to getting them f
 
 Next step is to change where our barchart gets its data. Gotta use the public URL.
 
-{caption: "Change data URL", line-numbers: false}
+{caption: "Change data URL", line-numbers: off}
 ```javascript
 //markua-start-delete
 d3.tsv("data.tsv", function(d) {
@@ -954,7 +954,7 @@ That's it. You now have a Barchart component that renders the example barchart f
 
 You can use it like this 👇 I recommend adding this code to the main App component that CodeSandbox creates for you.
 
-{caption: "Use the Barchart", line-numbers: false}
+{caption: "Use the Barchart", line-numbers: off}
 ```javascript
 import Barchart from './Barchart';
 
@@ -1026,7 +1026,7 @@ I recommend creating a new CodeSandbox, or starting a new app with create-react-
 
 Make sure you have `d3` added as a dependency. Then add imports in your `App.js` file.
 
-{caption: "Import files in App.js", line-numbers: false}
+{caption: "Import files in App.js", line-numbers: off}
 ```javascript
 // ./App.js
 
@@ -1036,7 +1036,7 @@ import Scatterplot from "./Scatterplot";
 
 Add an `<svg>` and render a Scatterplot in the render method. This will throw an error because we haven't defined the Scatterplot yet and that's okay.
 
-{caption: "Render Scatterplot in App.js", line-numbers: false}
+{caption: "Render Scatterplot in App.js", line-numbers: off}
 ```javascript
 // ./App.js
 
@@ -1071,7 +1071,7 @@ It also accepts data.
 
 We're using a line of code to generate data for our scatterplot. Put it in App.js. Either globally or within the App  function. Doesn't matter because this is an example.
 
-{caption: "Generate random data", line-numbers: false}
+{caption: "Generate random data", line-numbers: off}
 ```javascript
 const data = d3.range(100)
 							 .map(_ => [Math.random(), Math.random()]);
@@ -1085,7 +1085,7 @@ We iterate over this array and return a pair of random numbers for each entry. T
 
 Our scatterplot goes in a new `Scatterplot.js` file. Starts with imports and an empty React component.
 
-{caption: "Scatterplot stub", line-numbers: false}
+{caption: "Scatterplot stub", line-numbers: off}
 ```javascript
 // ./Scatterplot.js
 import React from "react";
@@ -1115,7 +1115,7 @@ Now we define D3 scales as component properties. We're using the class field syn
 
 Technically a Babel plugin, but comes by default with CodeSandbox React projects and create-react-app setup. As far as I can tell, it's a common way to write React components.
 
-{caption: "Add D3 scales", line-numbers: false}
+{caption: "Add D3 scales", line-numbers: off}
 ```javascript
 // ./Scatterplot.js
 class Scatterplot extends React.Component {
@@ -1137,7 +1137,7 @@ Idea being that these two scales will help us take those tiny variations in data
 
 Rendering our data points is a matter of looping over the data and rendering a `<circle>` for each entry. Using our scales to define positioning.
 
-{caption: "Loop through data and render circles", line-numbers: false}
+{caption: "Loop through data and render circles", line-numbers: off}
 ```javascript
 // ./Scatterplot.js
 
@@ -1160,7 +1160,7 @@ Mine take a scale and orientation as props, which makes them more flexible. Mean
 
 Put the axis code in `Axis.js`, then augment the Scatterplot like this 👇
 
-{caption: "Add axes to Scatterplot", line-numbers: false}
+{caption: "Add axes to Scatterplot", line-numbers: off}
 ```javascript
 import Axis from "./Axis";
 

--- a/manuscript/the-new-meat.md
+++ b/manuscript/the-new-meat.md
@@ -53,7 +53,7 @@ We'll put all of our components in `src/components/`.
 
 We start the component off with some imports, an export, and a functional stateless component that returns an empty div element.
 
-{format: javascript, line-numbers: false, caption: "Preloader skeleton"}
+{format: javascript, line-numbers: off, caption: "Preloader skeleton"}
 ```
 // src/components/Preloader.js
 
@@ -76,7 +76,7 @@ At the bottom, we `export default Preloader` so that we can use it in `App.js` a
 
 The `Preloader` function takes no props (because we don't need any) and returns an empty `div`. Let's fill it in.
 
-{format: javascript, line-numbers: false, caption: "Preloader content"}
+{format: javascript, line-numbers: off, caption: "Preloader content"}
 ```
 // src/components/Preloader.js
 
@@ -116,7 +116,7 @@ That will be a cornerstone of our project.
 
 We use our new Preloader component in App – `src/App.js`. Let's remove the `create-react-app` defaults and import our `Preloader` component.
 
-{format: javascript, line-numbers: false, caption: "Revamp App.js"}
+{format: javascript, line-numbers: off, caption: "Revamp App.js"}
 ```
 // src/App.js
 
@@ -155,7 +155,7 @@ We removed the logo and style imports, added an import for `Preloader`, and gutt
 
 Let's define a default `state` and a `render` method that uses our `Preloader` component when there's no data.
 
-{format: javascript, line-numbers: false, caption: "Render our preloader"}
+{format: javascript, line-numbers: off, caption: "Render our preloader"}
 ```
 // src/App.js
 
@@ -204,7 +204,7 @@ They'll make our fonts look better, help with layouting, and make buttons look l
 
 We load stylesheets in `src/index.js`.
 
-{format: javascript, line-numbers: false, caption: "Add Bootstrap in index.js"}
+{format: javascript, line-numbers: off, caption: "Add Bootstrap in index.js"}
 ```
 // src/index.js
 
@@ -261,7 +261,7 @@ Let's set up our `App` component first. That way you'll see results as soon data
 
 Start by importing our data loading method - `loadAllData` - and both D3 and Lodash. We'll need them later.
 
-{format: javascript, line-numbers: false, caption: "Import D3, lodash, and our loading method"}
+{format: javascript, line-numbers: off, caption: "Import D3, lodash, and our loading method"}
 ```
 // src/App.js
 import React from 'react';
@@ -280,7 +280,7 @@ You already know about default imports. Importing with `{}` is how we import nam
 
 Don't worry about the missing `DataHandling` file. It's coming soon.
 
-{format: javascript, line-numbers: false, caption: "Initiate data loading in App.js"}
+{format: javascript, line-numbers: off, caption: "Initiate data loading in App.js"}
 ```
 // src/App.js
 class App extends React.Component {
@@ -309,7 +309,7 @@ We also add two more entries to our `state`: `countyNames`, and `medianIncomes`.
 
 Let's change the `render` method to show a message when our data finishes loading.
 
-{format: javascript, line-numbers: false, caption: "Show when data loads"}
+{format: javascript, line-numbers: off, caption: "Show when data loads"}
 ```
 // src/App.js
 	render() {
@@ -355,7 +355,7 @@ We start with two imports and four data parsing functions:
 - `cleanSalary`, which parses each row of salary data
 - `cleanUSStateName`, which parses US state names
 
-{crop-start: 5, crop-end: 48, format: javascript, line-numbers: false}
+{crop-start: 5, crop-end: 48, format: javascript, line-numbers: off}
 ![Data parsing functions](code_samples/es6v2/DataHandling.js)
 
 You'll see those `d3` and `lodash` imports a lot.
@@ -368,7 +368,7 @@ Doing all this parsing now, keeps the rest of our codebase clean. Handling data 
 
 Now we can use D3 to load our data with fetch requests.
 
-{crop-start: 52, crop-end: 64, format: javascript, line-numbers: false}
+{crop-start: 52, crop-end: 64, format: javascript, line-numbers: off}
 ![Data loading](code_samples/es6v2/DataHandling.js)
 
 Here you can see another ES6 trick: default argument values. If `callback` is undefined, we set it to `_.noop` - a function that does nothing. This lets us later call `callback()` without worrying whether it's defined.
@@ -392,7 +392,7 @@ If you add a `console.log` to the `.then` callback above, you'll see a bunch of 
 
 To tie them together and prepare a dictionary for `setState` back in the `App` component, we need to add some logic. We're building a dictionary of county household incomes and removing any empty salaries.
 
-{crop-start: 68, crop-end: 92, format: javascript, line-numbers: false}
+{crop-start: 68, crop-end: 92, format: javascript, line-numbers: off}
 ![Tie our datasets together](code_samples/es6v2/DataHandling.js)
 
 Building the income map looks weird because of indentation, but it's not that bad. We `filter` the `medianIncomes` array to discard any incomes whose `countyName` we can't find. I made sure they were all unique when I built the datasets.
@@ -434,14 +434,14 @@ Just like before, we're going to start with changes in our `App` component, then
 
 You might guess the pattern already: add an import, add a helper method or two, update `render`.
 
-{crop-start: 119, crop-end: 126, format: javascript, line-numbers: false}
+{crop-start: 119, crop-end: 126, format: javascript, line-numbers: off}
 ![Import CountyMap component](code_samples/es6v2/App.js)
 
 That imports the `CountyMap` component from `components/CountyMap/`. Your browser will show an error overlay about some file or another until we're done.
 
 In the `App` class itself, we add a `countyValue` method. It takes a county entry and a map of tech salaries, and it returns the delta between median household income and a single tech salary.
 
-{crop-start: 129, crop-end: 144, format: javascript, line-numbers: false}
+{crop-start: 129, crop-end: 144, format: javascript, line-numbers: off}
 ![App.countyValue method](code_samples/es6v2/App.js)
 
 We use `this.state.medianIncomes` to get the median household salary and the `techSalariesMap` input to get salaries for a specific census area. Then we use `d3.median` to calculate the median value for salaries and return a two-element dictionary with the result.
@@ -454,7 +454,7 @@ In the `render` method, we'll:
  - remove the "data loaded" indicator
  - render the map
 
-{format: javascript, line-numbers: false, caption: "Render the CountyMap component}
+{format: javascript, line-numbers: off, caption: "Render the CountyMap component}
 ```
 // src/App.js
 render() {
@@ -510,7 +510,7 @@ In the `return` statement, we remove our "data loaded" indicator, and add an `<s
 
 We make `index.js` for just reason: to make imports and debugging easier. I learned this lesson the hard way so you don't have to.
 
-{format: javascript, line-numbers: false, line-numbers: false}
+{format: javascript, line-numbers: off, line-numbers: off}
 ![CountyMap index.js](code_samples/es6v2/components/CountyMap/index.js)
 
 Re-export the default import from `./CountyMap.js`. That's it.
@@ -527,7 +527,7 @@ We're using the [full-feature integration](#full-feature-integration) approach a
 
 Start with the imports: React, D3, lodash, topojson, County component.
 
-{crop-start: 5, crop-end: 12, format: javascript, line-numbers: false}
+{crop-start: 5, crop-end: 12, format: javascript, line-numbers: off}
 ![Import CountyMap dependencies](code_samples/es6v2/components/CountyMap/CountyMap.js)
 
 Out of these, we haven't built `County` yet, and you haven't seen `topojson` before. 
@@ -542,7 +542,7 @@ Maybe it's a case of [competing standards](https://xkcd.com/927/).
 
 We stub out the `CountyMap` component then fill it in with logic.
 
-{format: javascript, line-numbers: false, caption: "CountyMap stub"}
+{format: javascript, line-numbers: off, caption: "CountyMap stub"}
 ```
 // src/components/CountyMap/CountyMap.js
 class CountyMap extends Component {
@@ -577,7 +577,7 @@ We'll set up default D3 state in `constructor` and keep it up to date with `getD
 
 We need three D3 objects to build a choropleth map: a geographical projection, a path generator, and a quantize scale for colors.
 
-{format: javascript, line-numbers: false, caption: "D3 objects for a map"}
+{format: javascript, line-numbers: off, caption: "D3 objects for a map"}
 ```
 // src/components/CountyMap/CountyMap.js
 class CountyMap extends React.Component {
@@ -608,7 +608,7 @@ Let's say our domain goes from 0 to 90. Calling the scale with any number betwee
 
 Keeping our geo path and quantize scale up to date is simple, but we'll make it harder by adding a zoom feature. It won't work until we build the filtering, but hey, we'll already have it by then! :D
 
-{format: javascript, line-numbers: false, caption: "CountyMap getDerivedStateFromProps"}
+{format: javascript, line-numbers: off, caption: "CountyMap getDerivedStateFromProps"}
 ```
 		// src/components/CountyMap/CountyMap.js
     static getDerivedStateFromProps(props, state) {
@@ -673,7 +673,7 @@ Overall that makes your code easier to understand and closer to React principles
 
 After all that hard work, the `render` method is a breeze. We prep our data then loop through it and render a `County` element for each entry.
 
-{format: javascript, line-numbers: false, caption: "CountyMap render"}
+{format: javascript, line-numbers: off, caption: "CountyMap render"}
 ```
     render() {
         const { geoPath, quantize } = this.state,
@@ -737,14 +737,14 @@ For US state borders, we render a single `<path>` element and use `geoPath` to g
 
 The `County` component is built from two parts: imports and color constants, and a component that returns a `<path>`. All the hard calculation happens in `CountyMap`.
 
-{crop-start: 5, crop-end: 22, format: javascript, line-numbers: false}
+{crop-start: 5, crop-end: 22, format: javascript, line-numbers: off}
 ![Imports and color constants](code_samples/es6v2/components/CountyMap/County.js)
 
 We import React and Lodash, and define some color constants. I got the `ChoroplethColors` from some example online, and `BlankColor` is a pleasant gray.
 
 Now we need the `County` component.
 
-{crop-start: 27, crop-end: 53, format: javascript, line-numbers: false}
+{crop-start: 27, crop-end: 53, format: javascript, line-numbers: off}
 ![County component](code_samples/es6v2/components/CountyMap/County.js)
 
 The `render` method uses a `quantize` scale to pick the right color and returns a `<path>` element. `geoPath` generates the `d` attribute, we set style to `fill` the color, and we give our path a `title`.
@@ -786,7 +786,7 @@ We'll start our histogram with some changes in `App.js`, make a `Histogram` comp
 
 You know the drill, don't you? Import some stuff, add it to the `render()` method in the `App` component.
 
-{format: javascript, line-numbers: false, caption: "Histogram imports"}
+{format: javascript, line-numbers: off, caption: "Histogram imports"}
 ```
 // src/App.js
 import _ from 'lodash';
@@ -812,7 +812,7 @@ Personally I like to use CSS for general cross-component styling and styled-comp
 
 After the imports, we can render our `Histogram` in the `App` component.
 
-{crop-start: 205, crop-end: 235, format: javascript, line-numbers: false}
+{crop-start: 205, crop-end: 235, format: javascript, line-numbers: off}
 ![Render Histogram in App](code_samples/es6v2/App.js)
 
 We render the `Histogram` component with a bunch of props. They specify the dimensions we want, positioning, and pass data to the component. We're using `filteredSalaries` even though we haven't set up any filtering yet. One less line of code to change later 👌
@@ -830,7 +830,7 @@ The truth is somewhere in between. Do what fits your project and your team. We'r
 
 Create a new file `src/style.css` and add these 29 lines:
 
-{format: css, line-numbers: false, caption: "style.css stylesheet"}
+{format: css, line-numbers: off, caption: "style.css stylesheet"}
 ```
 .histogram .bar rect {
     fill: steelblue;
@@ -886,14 +886,14 @@ We'll use two components:
 
 Let's start with the basics: a `Histogram` directory and an `index.js` file. Keeps our code organized and imports easy. I like to use directories for components made of multiple files.
 
-{crop-start: 5, crop-end: 8, format: javascript, line-numbers: false}
+{crop-start: 5, crop-end: 8, format: javascript, line-numbers: off}
 ![Histogram index.js](code_samples/es6v2/components/Histogram/index.js)
 
 Import `Histogram` from `./Histogram` and export it as the `default` export. You could do it with a re-export: `export { default } from './Histogram'`. Not sure why I picked the long way. A dash more readable?
 
 Great, now we need the `Histogram.js` file. Start with some imports, a default export, and a stubbed out `Histogram` class.
 
-{format: javascript, line-numbers: false, caption: "Histogram component stub"}
+{format: javascript, line-numbers: off, caption: "Histogram component stub"}
 ```
 // src/components/Histogram/Histogram.js
 import React from "react";
@@ -937,7 +937,7 @@ Default `state` for our D3 objects: histogram, widthScale, and yScale. An empty
 
 ### getDerivedStateFromProps
 
-{format: javascript, line-numbers: false, caption: "getDerivedStateFromProps in Histogram"}
+{format: javascript, line-numbers: off, caption: "getDerivedStateFromProps in Histogram"}
 ```
 // src/components/Histogram/Histogram.js
     static getDerivedStateFromProps(props, state) {
@@ -985,7 +985,7 @@ Now let's render this puppy.
 
 ### render
 
-{format: javascript, line-numbers: false, caption: "Histogram.render"}
+{format: javascript, line-numbers: off, caption: "Histogram.render"}
 ```
 // src/components/Histogram/Histogram.js
 class Histogram extends React.Component {
@@ -1017,7 +1017,7 @@ This is a great example of React's declarativeness. We have a bunch of stuff, an
 
 `makeBar` is a function that takes a histogram bar's metadata and returns a `HistogramBar` component. We use it to make our declarative loop more readable.
 
-{format: javascript, line-numbers: false, caption: "Histogram.makeBar"}
+{format: javascript, line-numbers: off, caption: "Histogram.makeBar"}
 ```
 // src/components/Histogram/Histogram.js
 class Histogram extends React.Component {
@@ -1053,7 +1053,7 @@ Before our histogram shows up, we need another component: `HistogramBar`. We *co
 
 I like keeping small subcomponents like this in the same file as their parent. They don't work on their own so there's no reusability benefit from keeping them separate. And they're small enough that separating them doesn't help readability either.
 
-{crop-start: 120, crop-end: 150, format: javascript, line-numbers: false}
+{crop-start: 120, crop-end: 150, format: javascript, line-numbers: off}
 ![HistogramBar component](code_samples/es6v2/components/Histogram/Histogram.js)
 
 Pretty long for a functional component. Most of it goes into deciding how much precision to render in the label, so it's okay.
@@ -1074,7 +1074,7 @@ Our histogram is pretty, but it needs an axis to be useful. You've already learn
 
 We start with the D3blackbox higher order component. Same as before, except we put it in `src/components`. 
 
-{format: javascript, line-numbers: false, caption: "D3blackbox HOC"}
+{format: javascript, line-numbers: off, caption: "D3blackbox HOC"}
 ```
 import React from "react";
 
@@ -1105,7 +1105,7 @@ Take a `D3render` function, call it on `componentDidMount` and `componentDidUpda
 
 With `D3blackbox`, we can reduce the `Axis` component to a wrapped function. We're implementing the `D3render` method.
 
-{format: javascript, line-numbers: false, caption: "Axis component using D3blackbox"}
+{format: javascript, line-numbers: off, caption: "Axis component using D3blackbox"}
 ```
 import * as d3 from "d3";
 import D3blackbox from "../D3blackbox";
@@ -1136,7 +1136,7 @@ To render our new `Axis`, we add it to the `Histogram` component. It's a two ste
 1. Import `Axis` component
 2. Render it
 
-{format: javascript, line-numbers: false, caption: "Import and render Axis"}
+{format: javascript, line-numbers: off, caption: "Import and render Axis"}
 ```
 // src/components/Histogram/Histogram.js
 import React, { Component } from 'react';
@@ -1254,7 +1254,7 @@ Before we begin the `Title` component, there are a few things to take care of. O
 
 We make a `components/Meta` directory and add an `index.js`. It makes importing easier.
 
-{format: javascript, line-numbers: false, caption: "Meta index.js"}
+{format: javascript, line-numbers: off, caption: "Meta index.js"}
 ```
 // src/components/Meta/index.js
 export { default as Title } from './Title'
@@ -1275,7 +1275,7 @@ I know, it's confusing. They look like the same sentence turned around. Notice t
 
 We start with imports, a stub, and a default export.
 
-{crop-start: 5, crop-end: 29, format: javascript, line-numbers: false}
+{crop-start: 5, crop-end: 29, format: javascript, line-numbers: off}
 ![Title component stub](code_samples/es6v2/components/Meta/Title.js)
 
 We import only what we need from D3's `d3-scale` and `d3-array` packages. I consider this best practice until you're importing so much that it gets messy to look at.
@@ -1291,7 +1291,7 @@ In the `Title` component, we have 4 getters and a render. Getters are ES6 functi
 
 We can implement `yearsFragment`, `USstateFragment`, and `format` in one code sample. They're short.
 
-{crop-start: 35, crop-end: 55, format: javascript, line-numbers: false}
+{crop-start: 35, crop-end: 55, format: javascript, line-numbers: off}
 ![3 short getters in Title](code_samples/es6v2/components/Meta/Title.js)
 
 In both `yearsFragment` and `USstateFragment`, we get the appropriate value from Title's `filteredBy` prop, then return a string with the value or an empty string.
@@ -1302,7 +1302,7 @@ We rely on D3's built-in number formatters to build `format`. Linear scales have
 
 The `jobTitleFragment` getter is conceptually no harder than `yearsFragment` and `USstateFragment`, but it comes with a few more conditionals.
 
-{crop-start: 61, crop-end: 91, format: javascript, line-numbers: false}
+{crop-start: 61, crop-end: 91, format: javascript, line-numbers: off}
 ![Title.jobTitleFragment](code_samples/es6v2/components/Meta/Title.js)
 
 We're dealing with the `(jobTitle, year)` combination. Each influences the other when building the fragment for a total 4 different options.
@@ -1311,7 +1311,7 @@ We're dealing with the `(jobTitle, year)` combination. Each influences the other
 
 We put all this together in the `render` method. A conditional decides which of the two situations we're in, and we return an `<h2>` tag with the right text.
 
-{crop-start: 96, crop-end: 123, format: javascript, line-numbers: false}
+{crop-start: 96, crop-end: 123, format: javascript, line-numbers: off}
 ![Title.render](code_samples/es6v2/components/Meta/Title.js)
 
 Calculate the mean value using `d3.mean` with a value accessor, turn it into a pretty number with `this.format`, then use one of two string patterns to make a `title`.
@@ -1341,7 +1341,7 @@ We use the same approach as before:
 
 All the interesting complexity goes into finding the richest city and county. That part looks like this:
 
-{caption: "Richest county calculation", line-numbers: false}
+{caption: "Richest county calculation", line-numbers: off}
 ```javascript
 // src/components/Meta/Description.js
 get countyFragment() {
@@ -1390,7 +1390,7 @@ Inside `src/App.js`, we first have to add an import, then extract the median hou
 
 Let's see if we can do it in a single code block :smile:
 
-{crop-start: 282, crop-end: 317, format: javascript, line-numbers: false}
+{crop-start: 282, crop-end: 317, format: javascript, line-numbers: off}
 ![Adding MedianLine to App.js](code_samples/es6v2/App.js)
 
 You probably don't remember `medianIncomesByUSState` anymore. We set it up way back when [tying datasets together](#tie-datasets-together). It groups our salary data by US state.
@@ -1403,7 +1403,7 @@ When rendering `MedianLine`, we give it sizing and positioning props, the datase
 
 The `MedianLine` component looks similar to what you've seen so far. Some imports, a `constructor` that sets up D3 objects, an `updateD3` method that keeps them in sync, and a `render` method that outputs SVG.
 
-{ format: javascript, line-numbers: false, caption: "MedianLine component stub"}
+{ format: javascript, line-numbers: off, caption: "MedianLine component stub"}
 ```
 // src/components/MedianLine.js
 
@@ -1430,7 +1430,7 @@ We have some imports, a functional `MedianLine` component that takes our props, 
 
 Everything we need to render the line, fits into this function.
 
-{format: javascript, line-numbers: false, caption: "MedianLine render"}
+{format: javascript, line-numbers: off, caption: "MedianLine render"}
 ```
 // src/components/MedianLine.js
 
@@ -1471,7 +1471,7 @@ A `translate` SVG transform helps us position our line and label. We use it all 
 
 Building the `d` attribute for the path, that's interesting. We use a `line` generator from D3.
 
-{caption: "Line generator", line-numbers: false}
+{caption: "Line generator", line-numbers: off}
 ```javascript
 line = d3.line()([[0, 5], [width, 5]]);
 ```
@@ -1482,7 +1482,7 @@ That makes it span the entire width and leaves 5px for the label. We're using a 
 
 Remember, we already styled `medianLine` when we built [histogram styles](#histogram-css) earlier.
 
-{caption: "Histogram css", line-numbers: false}
+{caption: "Histogram css", line-numbers: off}
 ```css
 .mean text {
     font: 11px sans-serif;
@@ -1540,14 +1540,14 @@ All right, you know the drill. Add imports, tweak some things, add to render. We
 
 The white rectangle makes it so the zoomed-in map doesn't cover up the histogram. I'll explain when we get there.
 
-{crop-start: 323, crop-end: 356, format: javascript, line-numbers: false}
+{crop-start: 323, crop-end: 356, format: javascript, line-numbers: off}
 ![Imports and filter updates in App.js](code_samples/es6v2/App.js)
 
 We import the `Controls` component and add a default `salariesFilter` function to `this.state`. The `updateDataFilter` method passes the filter function and `filteredBy` dictionary from arguments to App state. We'll use it as a callback in `Controls`.
 
 The rest of filtering setup happens in the render method.
 
-{format: javascript, line-numbers: false, caption: "Filtering data and updating map zoom in App render"}
+{format: javascript, line-numbers: off, caption: "Filtering data and updating map zoom in App render"}
 ```
 // src/App.js
 class App extends React.Component {
@@ -1592,7 +1592,7 @@ And here's the downside of this approach. SVG doesn't know about element boundar
 
 See, it goes under the histogram. Let's fix that and add the `Controls` render while we're at it.
 
-{caption: "Add opaque background to histogram", crop-start: 396, crop-end: 426, format: javascript, line-numbers: false}
+{caption: "Add opaque background to histogram", crop-start: 396, crop-end: 426, format: javascript, line-numbers: off}
 ![](code_samples/es6v2/App.js)
 
 Rectangle, `500` to the right, `0` from top, `600` wide and `500` tall, with a white background. Gives the histogram an opaque background, so it doesn't matter what the map is doing.
@@ -1613,7 +1613,7 @@ Make a `Controls` directory in `src/components/` and let's begin. The main `Cont
 
 ### Stub Controls
 
-{format: javascript, line-numbers: false, caption: "Controls stubbed for year filter"}
+{format: javascript, line-numbers: off, caption: "Controls stubbed for year filter"}
 ```
 // src/components/Controls/index.js
 import React from "react";
@@ -1665,7 +1665,7 @@ We also need an `updateYearFilter` function, which we'll use to update the filte
 
 ### Filter logic
 
-{format: javascript, line-numbers: false, caption: "year filtering logic in Controls"}
+{format: javascript, line-numbers: off, caption: "year filtering logic in Controls"}
 ```
 // src/components/Controls/index.js
 class Controls extends React.Component {
@@ -1701,7 +1701,7 @@ When we have the `year` and `filter`, we update component state with `this.setSt
 
 `reportUpdateUpTheChain` then calls `this.props.updateDataFilter`, which is a callback method on `App`. We defined it earlier – it needs a new filter method and a `filteredBy` dictionary.
 
-{language: javascript, line-numbers: false, caption: "reportUpdateUpTheChain method"}
+{language: javascript, line-numbers: off, caption: "reportUpdateUpTheChain method"}
 ```
 // src/components/Controls/index.js
 class Controls extends React.Component {
@@ -1732,7 +1732,7 @@ It looks silly when there's just one filter, but I promise it makes sense.
 
 Great, we have the filter logic. Let's render those rows of controls we've been talking about.
 
-{format: javascript, line-numbers: false, caption: "Render the year ControlRow"}
+{format: javascript, line-numbers: off, caption: "Render the year ControlRow"}
 ```
 // src/components/Controls/index.js
 class Controls extends React.Component {
@@ -1768,7 +1768,7 @@ Let's build the `ControlRow` component. It renders a row of controls and ensures
 
 We'll start with a stub and go from there.
 
-{format: javascript, line-numbers: false, caption: "ControlRow stub"}
+{format: javascript, line-numbers: off, caption: "ControlRow stub"}
 ```
 // src/components/Controls/ControlRow.js
 import React from "react";
@@ -1797,7 +1797,7 @@ We start with imports, big surprise, then make a stub with 3 methods. Can you gu
 - `_addToggle` is a rendering helper method
 - `render` renders a row of buttons
 
-{format: javascript, line-numbers: false, caption: "makePick implementation"}
+{format: javascript, line-numbers: off, caption: "makePick implementation"}
 ```
 // src/components/Controls/ControlRow.js
 
@@ -1810,7 +1810,7 @@ class ControlRow extends React.Component {
 
 `makePick` calls the data filter update and passes in the new value and whether we want to unselect. Pretty simple right?
 
-{format: javascript, line-numbers: false, caption: "Render a row of controls"}
+{format: javascript, line-numbers: off, caption: "Render a row of controls"}
 ```
 // src/components/Controls/ControlRow.js
 class ControlRow extends React.Component {
@@ -1867,7 +1867,7 @@ Let's build it.
 
 Last piece of the puzzle – the Toggle component. A button that turns on and off.
 
-{format: javascript, line-numbers: false, caption: "Toggle component"}
+{format: javascript, line-numbers: off, caption: "Toggle component"}
 ```
 // src/components/Controls/Toggle.js
 import React from "react";
@@ -1908,7 +1908,7 @@ With all that done, we can add two more filters: US states and job titles. Our `
 
 We'll start with the `render` method, then handle the parts I said earlier would look repetitive.
 
-{crop-start: 102, crop-end: 137, format: javascript, line-numbers: false}
+{crop-start: 102, crop-end: 137, format: javascript, line-numbers: off}
 ![Adding two more rows to Controls](code_samples/es6v2/components/Controls/index.js)
 
 Ok, this part is plenty repetitive, too.
@@ -1917,7 +1917,7 @@ We created new sets for `jobTitles` and `USstates`, then rendered two more `Cont
 
 The implementations of those `updateDataFilter` callbacks follow the same pattern as `updateYearFilter`.
 
-{format: javascript, line-numbers: false, caption: "new updateDataFilter callbacks"}
+{format: javascript, line-numbers: off, caption: "new updateDataFilter callbacks"}
 ```
 // src/components/Controls/index.js
 
@@ -1977,7 +1977,7 @@ Why separate functions then? No need to get fancy. It would've made the code har
 
 Our last step is to add these new keys to the `reportUpdateUpTheChain` function.
 
-{format: javascript, line-numbers: false, caption: "Add new filters to main state update"}
+{format: javascript, line-numbers: off, caption: "Add new filters to main state update"}
 ```
 // src/components/Controls/index.js
 
@@ -2027,7 +2027,7 @@ There are many ways to achieve this. [ReactRouter](https://github.com/ReactTrain
 
 The easiest place to put this logic is next to the existing filter logic inside the `Controls` component. Better places exist from a "low-down components shouldn't play with global state" perspective, but that's okay.
 
-{crop-start: 215, crop-end: 243, format: javascript, line-numbers: false, caption: "Add rudimentary routing"}
+{crop-start: 215, crop-end: 243, format: javascript, line-numbers: off, caption: "Add rudimentary routing"}
 ```
 // src/components/Controls/index.js
 
@@ -2103,7 +2103,7 @@ For everyone else, head over to Github, click the green `New Repository` button 
 
 It should be something like this:
 
-{caption: "Put code on github", line-numbers: false}
+{caption: "Put code on github", line-numbers: off}
 ```
 $ git init
 $ git commit -m "My entire dataviz"
@@ -2117,14 +2117,14 @@ Every Github repository comes with an optional Github Pages setup. The easiest w
 
 Install it with this command:
 
-{caption: "Install gh-pages helper", line-numbers: false}
+{caption: "Install gh-pages helper", line-numbers: off}
 ```
 $ npm install --save-dev gh-pages
 ```
 
 Add two lines to package.json:
 
-{caption: "Update package.json", line-numbers: false}
+{caption: "Update package.json", line-numbers: off}
 ```json
 // package.json
 // markua-start-insert
@@ -2154,7 +2154,7 @@ And they're easy to set up. No excuse.
 
 We're going to poke around `public/index.html` for the first time. Add titles, Twitter cards, Facebook Open Graph things, and so on.
 
-{crop-start: 3, crop-end: 30, format: html, line-numbers: false}
+{crop-start: 3, crop-end: 30, format: html, line-numbers: off}
 ![Basic SEO](code_samples/es6v2/index.html)
 
 We add a `<title>` and a `canonical` URL. Titles configure what shows up in browser tabs, and the canonical URL is there to tell search engines that this is the main and most important URL for this piece of content. This is especially important for when people copy-paste your stuff and put it on other websites.
@@ -2165,7 +2165,7 @@ As soon as React loads, these get overwritten with our preloader, but it's good 
 
 To make social media embeds look great, we'll use [Twitter card](https://dev.twitter.com/cards/types/summary-large-image) and [Facebook OpenGraph](https://developers.facebook.com/docs/sharing/webmasters) meta tags. I think most other websites just rely on these since most people use them. They go in the `<head>` of our HTML.
 
-{crop-start: 34, crop-end: 64, format: javascript, line-numbers: false}
+{crop-start: 34, crop-end: 64, format: javascript, line-numbers: off}
 ![Add FB and Twitter cards](code_samples/es6v2/index.html)
 
 Much of this code is repetitive. Both Twitter and Facebook want the same info, but they're stubborn and won't read each other's formats. You can copy all of this, but make sure to change `og:url`, `og:site_name`, `article:publisher`, `fb:admins`, `og:image`, `twitter:site`, `twitter:image`, and `twitter:creator`. They're specific to you.
@@ -2186,7 +2186,7 @@ One more step left. Use the whole dataset!
 
 Go into `src/DataHandling.js` and change one line:
 
-{crop-start: 95, crop-end: 106, format: javascript, line-numbers: false}
+{crop-start: 95, crop-end: 106, format: javascript, line-numbers: off}
 ![Switch to full dataset](code_samples/es6v2/DataHandling.js)
 
 We change the file name, and that's that. Full dataset locked and loaded. Dataviz ready to go.


### PR DESCRIPTION
Leanpub's markua implementation doesn't cover `line-numbers: false` yet,
so it falls back to Leanpub-Flavored Markdown's `line-numbers: off`.