### PR TITLE
Convert emoji to github colon syntax and back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ skype_call.md
 team_license.md
 working_project.zip
 working_project/
-<<<<<<< HEAD
 working-environment.zip
 working-environment/
 *.epub
@@ -22,5 +21,4 @@ team*.txt
 livecoding_sessions.txt
 30min_call.txt
 .DS_Store
-=======
->>>>>>> a6192cc914d93e00aff8c2cd8865d3bc29fc78fa
+node_modules

--- a/manuscript/emoji.js
+++ b/manuscript/emoji.js
@@ -1,0 +1,96 @@
+const fs = require("fs");
+const fetch = require("node-fetch");
+const emojiPatterns = require("emoji-patterns");
+const sync = require("glob-gitignore").sync;
+
+const emojiAllRegexp = new RegExp(emojiPatterns["Emoji_All"], "gu");
+
+function emojiAliasDict(emojiData) {
+  return emojiData.reduce(
+    (dictionary, item) => (
+      (dictionary[item.emoji] = `:${item.aliases[0]}:`), dictionary
+    ),
+    {}
+  );
+}
+
+function aliasEmojiDict(emojiData) {
+  return emojiData.reduce((dictionary, item) => {
+    item.aliases.forEach(alias => {
+      dictionary[`:${alias}:`] = item.emoji;
+    });
+    return dictionary;
+  }, {});
+}
+
+console.log(process.argv);
+
+fetch("https://www.gitcdn.xyz/repo/github/gemoji/master/db/emoji.json")
+  .then(res => res.json())
+  .then(json => {
+    const textFilePaths = sync(["**/*.md", "**/*.txt"], {
+      ignore: "node_modules/*"
+    });
+    console.log({ textFilePaths });
+
+    const conversionDirection = process.argv[2];
+
+    if (conversionDirection === "--colonify") {
+      const dictionary = emojiAliasDict(json);
+
+      textFilePaths.forEach(textFilePath => {
+        const originalFile = fs.createReadStream(textFilePath, "utf8");
+        let transformedContent = "";
+
+        originalFile.on("data", chunk => {
+          transformedContent += chunk
+            .toString()
+            .replace(emojiAllRegexp, emoji => {
+              const alias = dictionary[emoji];
+              if (alias) console.log(`${textFilePath} ${emoji} ${alias}`);
+              const replacement = alias || emoji;
+
+              return replacement;
+            });
+        });
+
+        originalFile.on("end", () => {
+          fs.writeFile(textFilePath, transformedContent, err => {
+            if (err) {
+              return console.log(err);
+            }
+          });
+        });
+      });
+    } else if (conversionDirection === "--emojify") {
+      const dictionary = aliasEmojiDict(json);
+      const regexpString = "(" + Object.keys(dictionary).join("|") + ")";
+
+      const aliasAllRegexp = new RegExp(regexpString, "g");
+
+      textFilePaths.forEach(textFilePath => {
+        const originalFile = fs.createReadStream(textFilePath, "utf8");
+        let transformedContent = "";
+
+        originalFile.on("data", chunk => {
+          transformedContent += chunk
+            .toString()
+            .replace(aliasAllRegexp, alias => {
+              const emoji = dictionary[alias];
+              if (emoji) console.log(`${textFilePath} ${alias} ${emoji}`);
+              const replacement = emoji || alias;
+
+              return replacement;
+            });
+        });
+
+        originalFile.on("end", () => {
+          fs.writeFile(textFilePath, transformedContent, err => {
+            if (err) {
+              return console.log(err);
+            }
+          });
+        });
+      });
+    }
+  });

--- a/manuscript/package-lock.json
+++ b/manuscript/package-lock.json
@@ -1,0 +1,133 @@
+{
+  "name": "manuscript",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "emoji-patterns": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-patterns/-/emoji-patterns-11.2.2.tgz",
+      "integrity": "sha512-9vEqOQo/ftHckHBUIivn3fn6JQ+rCsvQi4tnZ8MTmaMSAOlEDfalYd8JYHwD50BkYCybYiO9ktqXkkSEZGVnsw=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-gitignore": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.11.tgz",
+      "integrity": "sha512-lwUELCBEqLwUAKd2VdUl/t3HFfYPKbmjQfXsVaES5Amjvj3PZHzR0yQTSxcI4dFfMrZEZS3+e7Sthw+6a3Qgbg==",
+      "requires": {
+        "glob": "^7.1.3",
+        "ignore": "^4.0.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.union": "^4.6.0",
+        "make-array": "^1.0.5",
+        "util.inherits": "^1.0.3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+    },
+    "make-array": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/make-array/-/make-array-1.0.5.tgz",
+      "integrity": "sha512-sgK2SAzxT19rWU+qxKUcn6PAh/swiIiz2F8C2cZjLc1z4iwYIfdoihqFIDQ8BDzAGtWPYJ6Sr13K1j/DXynDLA=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "util.inherits": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util.inherits/-/util.inherits-1.0.3.tgz",
+      "integrity": "sha1-qcYmoNBtNIKdR7pWyrEnjXRfnOY="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/manuscript/package.json
+++ b/manuscript/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "manuscript",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "colonify": "node emoji.js --colonify",
+    "emojify": "node emoji.js --emojify"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "emoji-patterns": "^11.2.2",
+    "glob-gitignore": "^1.0.11",
+    "node-fetch": "^2.2.0"
+  }
+}


### PR DESCRIPTION
To convert emoji literals to github colon syntax:

```
npm run colonify
```

To convert github colon syntax to emoji literals:

```
npm run emojify
```

I've tested rendering of colon syntax on Remarq.io and it works! It's good to have the option to convert back though in order to render to HTML and other formats as needed.