### PR TITLE
Fix LaTeX image positioning

### DIFF
--- a/remarq.js
+++ b/remarq.js
@@ -70,11 +70,20 @@ const normalizeHeadings = fp.curry((baseHeading, markdownString) => {
   }
 });
 
+// Add a LaTeX non-breaking space after the image so that it gets
+// rendered where it appears in the manuscript instead of some odd
+// position decided by LaTeX
+const fixLatexImagePosition = fp.replace(
+  /!\[.*?]\(.*?\.(?:png|jpg|gif)\)/g,
+  '$&\\ '
+);
+
 // ## effectful functions
 function writeOutSectionsAsRemarqChaptersFile(sections) {
   const fullRemarqBody = fp.pipe(
     fp.map(fixSectionBody),
     fp.join('\n\n'),
+    fixLatexImagePosition,
     fpWriteFile(remarqInputChaptersFileAbsPath)
   )(sections);
 


### PR DESCRIPTION
Fixes the problem of LaTeX positioning images at arbitrary places. Now they are printed in the same position as they are referred to in the manuscript, making the text non-confusing.

Credits to Jeremy for pointing out the nonbreaking space hack.